### PR TITLE
Using dependency packages with git and package options instead of path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,13 +186,13 @@ name = "brack"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "brack-codegen",
- "brack-expander",
- "brack-language-server",
- "brack-parser",
- "brack-plugin",
- "brack-plugin-manager",
- "brack-tokenizer",
+ "brack-codegen 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-expander 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-language-server 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin-manager 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-tokenizer 0.1.0 (git+https://github.com/brack-lang/brack)",
  "clap",
  "tokio",
  "toml 0.8.8",
@@ -203,9 +203,21 @@ name = "brack-codegen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "brack-parser",
- "brack-plugin",
- "brack-sdk-rs",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "extism",
+]
+
+[[package]]
+name = "brack-codegen"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
  "extism",
 ]
 
@@ -214,9 +226,21 @@ name = "brack-expander"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "brack-parser",
- "brack-plugin",
- "brack-sdk-rs",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "extism",
+]
+
+[[package]]
+name = "brack-expander"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-plugin 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
  "extism",
 ]
 
@@ -232,12 +256,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "brack-language-server"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "lsp-types",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "brack-parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "brack-sdk-rs",
- "brack-tokenizer",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-tokenizer 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "brack-parser"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-tokenizer 0.1.0 (git+https://github.com/brack-lang/brack)",
  "serde",
  "serde_json",
  "thiserror",
@@ -249,8 +299,25 @@ name = "brack-plugin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "brack-parser",
- "brack-sdk-rs",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "extism",
+ "extism-convert",
+ "modsurfer-plugins",
+ "modsurfer-proto",
+ "protobuf",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "brack-plugin"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "brack-parser 0.1.0 (git+https://github.com/brack-lang/brack)",
+ "brack-sdk-rs 0.1.0 (git+https://github.com/brack-lang/brack)",
  "extism",
  "extism-convert",
  "modsurfer-plugins",
@@ -272,6 +339,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "brack-plugin-manager"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "tokio",
+ "toml 0.8.8",
+]
+
+[[package]]
 name = "brack-sdk-rs"
 version = "0.1.0"
 dependencies = [
@@ -281,8 +360,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brack-sdk-rs"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "brack-tokenizer"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "brack-tokenizer"
+version = "0.1.0"
+source = "git+https://github.com/brack-lang/brack#8b1000ce0ddd7cc9446f2210f7474dd2d61d903c"
 dependencies = [
  "anyhow",
  "unicode-segmentation",

--- a/brack-codegen/Cargo.toml
+++ b/brack-codegen/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
-brack-parser = { path = "../brack-parser" }
-brack-plugin = { path = "../brack-plugin" }
-brack-sdk-rs = { path = "../brack-sdk-rs" }
+brack-parser = { git = "https://github.com/brack-lang/brack", package = "brack-parser" }
+brack-plugin = { git = "https://github.com/brack-lang/brack", package = "brack-plugin" }
+brack-sdk-rs = { git = "https://github.com/brack-lang/brack", package = "brack-sdk-rs" }
 extism = "^1.0.0-rc3"

--- a/brack-expander/Cargo.toml
+++ b/brack-expander/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.77"
-brack-sdk-rs = { path = "../brack-sdk-rs" }
-brack-plugin = { path = "../brack-plugin" }
-brack-parser = { path = "../brack-parser" }
+brack-sdk-rs = { git = "https://github.com/brack-lang/brack", package = "brack-sdk-rs" }
+brack-plugin = { git = "https://github.com/brack-lang/brack", package = "brack-plugin" }
+brack-parser = { git = "https://github.com/brack-lang/brack", package = "brack-parser" }
 extism = "^1.0.0-rc3"

--- a/brack-parser/Cargo.toml
+++ b/brack-parser/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
-brack-tokenizer = { path = "../brack-tokenizer" }
-brack-sdk-rs = { path = "../brack-sdk-rs" }
+brack-tokenizer = { git = "https://github.com/brack-lang/brack", package = "brack-tokenizer" }
+brack-sdk-rs = { git = "https://github.com/brack-lang/brack", package = "brack-sdk-rs" }
 serde = { versopm = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
 thiserror = "1.0.56"

--- a/brack-plugin/Cargo.toml
+++ b/brack-plugin/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.77"
-brack-parser = { path = "../brack-parser" }
-brack-sdk-rs = { path = "../brack-sdk-rs/" }
+brack-parser = { git = "https://github.com/brack-lang/brack", package = "brack-parser" }
+brack-sdk-rs = { git = "https://github.com/brack-lang/brack", package = "brack-sdk-rs" }
 extism = "^1.0.0-rc3"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"

--- a/brack/Cargo.toml
+++ b/brack/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
-brack-codegen = { path = "../brack-codegen" }
-brack-expander = { path = "../brack-expander" }
-brack-language-server = { path = "../brack-language-server" }
-brack-parser = { path = "../brack-parser" }
-brack-plugin = { path = "../brack-plugin" }
-brack-plugin-manager = { path = "../brack-plugin-manager" }
-brack-tokenizer = { path = "../brack-tokenizer" }
+brack-codegen = { git = "https://github.com/brack-lang/brack", package = "brack-codegen" }
+brack-expander = { git = "https://github.com/brack-lang/brack", package = "brack-expander" }
+brack-language-server = { git = "https://github.com/brack-lang/brack", package = "brack-language-server" }
+brack-parser = { git = "https://github.com/brack-lang/brack", package = "brack-parser" }
+brack-plugin = { git = "https://github.com/brack-lang/brack", package = "brack-plugin" }
+brack-plugin-manager = { git = "https://github.com/brack-lang/brack", package = "brack-plugin-manager" }
+brack-tokenizer = { git = "https://github.com/brack-lang/brack", package = "brack-tokenizer" }
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.8"
 


### PR DESCRIPTION
I have fixed the way to specify packages to publish a brack binary on crate.io. They prohibit publishing packages whose settings include a relative path.