### PR TITLE
Modsurfer removed to build successfully with Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
+        with:
+          name: brack-lang
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix build .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,32 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    paths-ignore:
+      - '.vscode/**'
+      - '.gitignore'
+      - 'LICENSE*'
+      - 'brack.ebnf'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - '.vscode/**'
+      - '.gitignore'
+      - 'LICENSE*'
+      - 'brack.ebnf'
+      - '*.md'
 
 jobs:
-    test:
-        runs-on: ubuntu-22.04
-        steps:
-        - uses: actions/checkout@v4
-        - uses: dtolnay/rust-toolchain@stable
-        - run: cargo test --all-features
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all-features
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - run: nix build .
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,6 @@ dependencies = [
  "brack-sdk-rs",
  "extism",
  "extism-convert",
- "modsurfer-plugins",
- "modsurfer-proto",
- "protobuf",
  "serde",
  "serde_json",
 ]
@@ -789,7 +786,6 @@ dependencies = [
  "bytemuck",
  "extism-convert-macros",
  "prost",
- "protobuf",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1452,19 +1448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "modsurfer-plugins"
-version = "0.1.0"
-source = "git+https://github.com/dylibso/modsurfer#5d9c236c707dadec46cc5aa2a0a5d88a6370c553"
-
-[[package]]
-name = "modsurfer-proto"
-version = "0.1.0"
-source = "git+https://github.com/dylibso/modsurfer#5d9c236c707dadec46cc5aa2a0a5d88a6370c553"
-dependencies = [
- "protobuf",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,26 +1671,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
-]
-
-[[package]]
-name = "protobuf"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58678a64de2fced2bdec6bca052a6716a0efe692d6e3f53d1bda6a1def64cfc0"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ed294a835b0f30810e13616b1cd34943c6d1e84a8f3b0dcfe466d256c3e7e7"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]

--- a/brack-codegen/src/curly.rs
+++ b/brack-codegen/src/curly.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use brack_plugin::plugin::{arg_counter, Plugins2};
+use brack_plugin::plugin::{arg_counter, Plugins};
 use brack_sdk_rs::{ast::AST, Type, Value};
 use extism::convert::Json;
 
 use crate::{expr, identifier, square, text};
 
-pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
+pub fn generate(ast: &AST, plugins: &mut Plugins) -> Result<String> {
     let mut module_name = String::from("");
     let mut ident_name = String::from("");
 
@@ -32,14 +32,24 @@ pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
         }
     }
 
-    let (plugin, plugin_metadata_map) = plugins.get_mut(&module_name).ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
-    let plugin_metadata = plugin_metadata_map.get(&(ident_name.clone(), Type::TBlock)).ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
+    let (plugin, plugin_metadata_map) = plugins
+        .get_mut(&module_name)
+        .ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
+    let plugin_metadata = plugin_metadata_map
+        .get(&(ident_name.clone(), Type::TBlock))
+        .ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
     let arg_types = &plugin_metadata.argument_types;
-    
-    let (min, max) = arg_counter(&arg_types.iter().map(|(_, t)| t).cloned().collect::<Vec<_>>());
+
+    let (min, max) = arg_counter(
+        &arg_types
+            .iter()
+            .map(|(_, t)| t)
+            .cloned()
+            .collect::<Vec<_>>(),
+    );
 
     if arguments.len() < min {
-        // TODO: show the signature of the command 
+        // TODO: show the signature of the command
         anyhow::bail!("{} requires at least {} arguments", ident_name, min);
     }
     if arguments.len() > max {
@@ -57,12 +67,8 @@ pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
                     Value::TextOption(None)
                 }
             }
-            Type::TArray(_) => {
-                Value::TextArray(arguments[i..].iter().map(|s| s.clone()).collect())
-            },
-            _ => {
-                Value::Text(arguments[i].clone())
-            }
+            Type::TArray(_) => Value::TextArray(arguments[i..].iter().map(|s| s.clone()).collect()),
+            _ => Value::Text(arguments[i].clone()),
         };
         args.push(arg);
     }

--- a/brack-codegen/src/expr.rs
+++ b/brack-codegen/src/expr.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use brack_plugin::plugin::Plugins2;
+use brack_plugin::plugin::Plugins;
 use brack_sdk_rs::ast::AST;
 
 use crate::{identifier, square, text};
 
-pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
+pub fn generate(ast: &AST, plugins: &mut Plugins) -> Result<String> {
     let mut result = String::from("");
     for child in ast.children() {
         let res = match child {

--- a/brack-codegen/src/generate.rs
+++ b/brack-codegen/src/generate.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use brack_plugin::plugin::Plugins2;
+use brack_plugin::plugin::Plugins;
 use brack_sdk_rs::ast::AST;
 
 use crate::{curly, expr, identifier, square, stmt, text};
 
-pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
+pub fn generate(ast: &AST, plugins: &mut Plugins) -> Result<String> {
     let mut result = String::from("");
     for child in ast.children() {
         let res = match child {

--- a/brack-codegen/src/square.rs
+++ b/brack-codegen/src/square.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
-use brack_plugin::plugin::{arg_counter, Plugins2};
+use brack_plugin::plugin::{arg_counter, Plugins};
 use brack_sdk_rs::{ast::AST, Type, Value};
 use extism::convert::Json;
 
 use crate::{curly, expr, identifier, text};
 
-pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
+pub fn generate(ast: &AST, plugins: &mut Plugins) -> Result<String> {
     let mut module_name = String::from("");
     let mut ident_name = String::from("");
 
@@ -32,14 +32,24 @@ pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
         }
     }
 
-    let (plugin, plugin_metadata_map) = plugins.get_mut(&module_name).ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
-    let plugin_metadata = plugin_metadata_map.get(&(ident_name.clone(), Type::TInline)).ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
+    let (plugin, plugin_metadata_map) = plugins
+        .get_mut(&module_name)
+        .ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
+    let plugin_metadata = plugin_metadata_map
+        .get(&(ident_name.clone(), Type::TInline))
+        .ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
     let arg_types = &plugin_metadata.argument_types;
-    
-    let (min, max) = arg_counter(&arg_types.iter().map(|(_, t)| t).cloned().collect::<Vec<_>>());
+
+    let (min, max) = arg_counter(
+        &arg_types
+            .iter()
+            .map(|(_, t)| t)
+            .cloned()
+            .collect::<Vec<_>>(),
+    );
 
     if arguments.len() < min {
-        // TODO: show the signature of the command 
+        // TODO: show the signature of the command
         anyhow::bail!("{} requires at least {} arguments", ident_name, min);
     }
     if arguments.len() > max {
@@ -57,12 +67,8 @@ pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
                     Value::TextOption(None)
                 }
             }
-            Type::TArray(_) => {
-                Value::TextArray(arguments[i..].iter().map(|s| s.clone()).collect())
-            },
-            _ => {
-                Value::Text(arguments[i].clone())
-            }
+            Type::TArray(_) => Value::TextArray(arguments[i..].iter().map(|s| s.clone()).collect()),
+            _ => Value::Text(arguments[i].clone()),
         };
         args.push(arg);
     }

--- a/brack-codegen/src/stmt.rs
+++ b/brack-codegen/src/stmt.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use brack_plugin::plugin::Plugins2;
+use brack_plugin::plugin::Plugins;
 use brack_sdk_rs::ast::AST;
 
 use crate::{curly, expr, identifier, square, text};
 
-pub fn generate(ast: &AST, plugins: &mut Plugins2) -> Result<String> {
+pub fn generate(ast: &AST, plugins: &mut Plugins) -> Result<String> {
     let mut result = String::from("");
     for child in ast.children() {
         let res = match child {

--- a/brack-expander/src/expand.rs
+++ b/brack-expander/src/expand.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use brack_plugin::plugin::Plugins2;
+use brack_plugin::plugin::Plugins;
 use brack_sdk_rs::{ast::AST, Type};
 use extism::convert::Json;
 
-fn expand_angle(overall_ast: &AST, ast: &AST, plugins: &mut Plugins2) -> Result<AST> {
+fn expand_angle(overall_ast: &AST, ast: &AST, plugins: &mut Plugins) -> Result<AST> {
     let mut module_name = String::from("");
     let mut ident_name = String::from("");
 
@@ -31,15 +31,21 @@ fn expand_angle(overall_ast: &AST, ast: &AST, plugins: &mut Plugins2) -> Result<
         break;
     }
 
-    let (plugin, plugin_metadata_map) = plugins.get_mut(&module_name).ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
-    let plugin_metadata = plugin_metadata_map.get(&(ident_name.clone(), Type::TAST)).ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
-    let Json(res) =
-        plugin.call::<Json<(AST, String)>, Json<AST>>(&plugin_metadata.call_name, Json((overall_ast.clone(), ast.id())))?;
+    let (plugin, plugin_metadata_map) = plugins
+        .get_mut(&module_name)
+        .ok_or_else(|| anyhow::anyhow!("Module {} not found", module_name))?;
+    let plugin_metadata = plugin_metadata_map
+        .get(&(ident_name.clone(), Type::TAST))
+        .ok_or_else(|| anyhow::anyhow!("Command {} not found", ident_name))?;
+    let Json(res) = plugin.call::<Json<(AST, String)>, Json<AST>>(
+        &plugin_metadata.call_name,
+        Json((overall_ast.clone(), ast.id())),
+    )?;
 
     Ok(res)
 }
 
-fn expand_other(overall_ast: &AST, ast: &AST, plugins: &mut Plugins2) -> Result<AST> {
+fn expand_other(overall_ast: &AST, ast: &AST, plugins: &mut Plugins) -> Result<AST> {
     let mut children = vec![];
     match ast {
         AST::Text(_) => {
@@ -56,7 +62,7 @@ fn expand_other(overall_ast: &AST, ast: &AST, plugins: &mut Plugins2) -> Result<
     Ok(ast.clone())
 }
 
-pub fn expander(ast: &AST, plugins: &mut Plugins2) -> Result<AST> {
+pub fn expander(ast: &AST, plugins: &mut Plugins) -> Result<AST> {
     let overall_ast = ast.clone();
     Ok(expand_other(&overall_ast, ast, plugins)?)
 }

--- a/brack-plugin/Cargo.toml
+++ b/brack-plugin/Cargo.toml
@@ -12,7 +12,4 @@ brack-sdk-rs = { git = "https://github.com/brack-lang/brack", package = "brack-s
 extism = "^1.0.0-rc3"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
-protobuf = "=3.4.0"
-modsurfer-proto = { git = "https://github.com/dylibso/modsurfer", package = "modsurfer-proto" }
-modsurfer-plugins = { git = "https://github.com/dylibso/modsurfer", package = "modsurfer-plugins" }
-extism-convert = { version = "1.0.3", features = ["protobuf"] }
+extism-convert = { version = "1.0.3" }

--- a/brack-plugin/src/plugin.rs
+++ b/brack-plugin/src/plugin.rs
@@ -2,70 +2,21 @@ use std::{collections::HashMap, fs, path::Path};
 
 use anyhow::Result;
 use brack_sdk_rs::{MetaData, Type};
-use extism::{Manifest, Plugin, Wasm};
-use extism_convert::{Json, Protobuf};
-use modsurfer_plugins::MODSURFER_WASM;
-use modsurfer_proto::api::Module;
-use protobuf::MessageField;
-
-pub type Plugins = HashMap<String, Plugin>;
+use extism::Plugin;
+use extism_convert::Json;
 
 pub type ModuleName = String;
 pub type CommandName = String;
-pub type Plugins2 = HashMap<ModuleName, (Plugin, PluginMetaDataMap)>;
+pub type Plugins = HashMap<ModuleName, (Plugin, PluginMetaDataMap)>;
 pub type PluginMetaDataMap = HashMap<(CommandName, Type), MetaData>;
 
 pub fn new_plugins<P: AsRef<Path>>(pathes: Vec<P>) -> Result<Plugins> {
-    let mut hash = HashMap::new();
-    for path in pathes {
-        let wasm = Wasm::file(&path);
-        let manifest = Manifest::new([wasm]);
-        let plugin = Plugin::new(&manifest, [], true)?;
-
-        let file_stem = path
-            .as_ref()
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or_default();
-        let parts: Vec<&str> = file_stem.split('.').collect();
-        let name = parts.get(0).map_or("", |s| *s).to_string();
-
-        hash.insert(name, plugin);
-    }
-    Ok(hash)
-}
-
-pub fn get_metadata_functions<P: AsRef<Path>>(
-    modsurfer: &mut Plugin,
-    path: P,
-) -> Result<Vec<String>> {
-    let wasm = fs::read(path)?;
-    let Protobuf(data) =
-        modsurfer.call::<Vec<u8>, Protobuf<Module>>("parse_module", wasm.clone())?;
-    let mut all_functions = vec![];
-    for export in data.exports {
-        if let MessageField(Some(f)) = export.func {
-            all_functions.push(f.name);
-        }
-    }
-    let result = all_functions
-        .iter()
-        .filter(|&x| x.starts_with("metadata_"))
-        .cloned()
-        .collect::<Vec<_>>();
-    Ok(result)
-}
-
-pub fn new_plugins2<P: AsRef<Path>>(pathes: Vec<P>) -> Result<Plugins2> {
     let mut result = HashMap::new();
-    let mut modsurfer = Plugin::new(MODSURFER_WASM, [], false)?;
     for path in pathes {
-        let metadata_functions = get_metadata_functions(&mut modsurfer, &path)?;
-        let mut plugin = Plugin::new(fs::read(&path)?, [], false)?;
+        let mut extism_plugin = Plugin::new(fs::read(&path)?, [], true)?;
+        let Json(metadatas) = extism_plugin.call::<(), Json<Vec<MetaData>>>("get_metadata", ())?;
         let mut metadata_map = HashMap::new();
-        for metadata_function in metadata_functions {
-            let Json(metadata) =
-                plugin.call::<(), extism_convert::Json<MetaData>>(&metadata_function, ())?;
+        for metadata in metadatas {
             metadata_map.insert(
                 (metadata.command_name.clone(), metadata.return_type.clone()),
                 metadata,
@@ -78,7 +29,7 @@ pub fn new_plugins2<P: AsRef<Path>>(pathes: Vec<P>) -> Result<Plugins2> {
             .unwrap_or_default();
         let parts: Vec<&str> = file_stem.split('.').collect();
         let name = parts.get(0).map_or("", |s| *s).to_string();
-        result.insert(name, (plugin, metadata_map));
+        result.insert(name, (extism_plugin, metadata_map));
     }
     Ok(result)
 }
@@ -103,60 +54,4 @@ pub fn arg_counter(arg_types: &Vec<Type>) -> (usize, usize) {
         }
     }
     (min, max)
-}
-
-#[cfg(test)]
-mod tests {
-    use core::panic;
-
-    use super::*;
-    use brack_parser::ast::new_document;
-    use brack_sdk_rs::{ast::AST, Type, Value};
-    use extism_convert::Json;
-
-    #[test]
-    fn test1() {
-        let mut plugins2 = new_plugins2(vec!["./test.html.wasm"]).unwrap();
-        let (plugin, metadata_map) = plugins2.get_mut("test").unwrap();
-
-        match metadata_map.get(&("@".to_string(), Type::TInline)) {
-            Some(metadata) => {
-                match plugin.call::<Json<Vec<Value>>, String>(
-                    metadata.call_name.clone(),
-                    Json(vec![
-                        Value::Text("https://github.com/momeemt".to_string()),
-                        Value::TextOption(Some("GitHub".to_string())),
-                    ]),
-                ) {
-                    Ok(processed) => assert_eq!(
-                        processed,
-                        "<a href=\"https://github.com/momeemt\">GitHub</a>"
-                    ),
-                    Err(e) => panic!("{:?}", e),
-                }
-            }
-            _ => panic!("No metadata found for @"),
-        }
-    }
-
-    #[test]
-    fn test_macro() {
-        let mut plugins2 = new_plugins2(vec!["./test.html.wasm"]).unwrap();
-        let (plugin, metadata_map) = plugins2.get_mut("test").unwrap();
-
-        let ast = new_document();
-
-        match metadata_map.get(&("^".to_string(), Type::TAST)) {
-            Some(metadata) => {
-                match plugin.call::<Json<(AST, String)>, Json<AST>>(
-                    metadata.call_name.clone(),
-                    Json((ast.clone(), ast.id())),
-                ) {
-                    Ok(Json(ast)) => println!("{:?}", ast),
-                    Err(e) => panic!("{:?}", e),
-                }
-            }
-            _ => panic!("No metadata found for ^"),
-        }
-    }
 }

--- a/brack/src/main.rs
+++ b/brack/src/main.rs
@@ -67,7 +67,7 @@ fn run_compile(subcommand: SubCommands) -> Result<()> {
         }
     }
 
-    let mut plugins = brack_plugin::plugin::new_plugins2(pathes)?;
+    let mut plugins = brack_plugin::plugin::new_plugins(pathes)?;
 
     if !args.2.ends_with(".[]") {
         anyhow::bail!("Filename must end with .[]");
@@ -132,7 +132,7 @@ fn build() -> Result<()> {
         }
     }
 
-    let mut plugins = brack_plugin::plugin::new_plugins2(pathes)?;
+    let mut plugins = brack_plugin::plugin::new_plugins(pathes)?;
 
     let entries = read_dir("docs")?;
     for entry in entries {

--- a/flake.lock
+++ b/flake.lock
@@ -1,45 +1,26 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1705472611,
-        "narHash": "sha256-o9zxn4OPM6ltNmsiIK4Fl1k6aIF73x2wELGeCQYdO0k=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "39ef99bcc06101639781bdb5dd69155b7033badd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1705309234,
@@ -55,69 +36,66 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1698420672,
-        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701282334,
-        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "23.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "fenix": "fenix",
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
       }
     },
-    "rust-analyzer-src": {
-      "flake": false,
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1705432736,
-        "narHash": "sha256-uUS5B8ypVevvhjA/2smEOu5s8zK3MBJU5tH0Tze3Kok=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "03336460fcb25a86675aaff9694998f5910ff747",
+        "lastModified": 1718590793,
+        "narHash": "sha256-92OO8XrQTvdvDtRi0BAkjTaoZXW5ORuvqdk677wW7ko=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "5265b8a1e1d2e370e8b45b557326b691aec7d163",
         "type": "github"
       },
       "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             lockFile = ./Cargo.lock;
           };
           nativeBuildInputs = with pkgs; [
-            pkgs-config
+            pkg-config
           ];
           buildInputs = with pkgs;
             [

--- a/flake.nix
+++ b/flake.nix
@@ -1,54 +1,52 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/23.11";
-    fenix = {
-      url = "github:nix-community/fenix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    naersk = {
-      url = "github:nix-community/naersk";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
   };
-  outputs = { self, nixpkgs, fenix, naersk, flake-utils, flake-compat, ... }:
+
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    flake-utils,
+  }:
     flake-utils.lib.eachDefaultSystem (
       system: let
-        overlays = [
-          (_: super: let pkgs = fenix.inputs.nixpkgs.legacyPackages.${super.system}; in fenix.overlays.default pkgs pkgs)
-        ];
         pkgs = import nixpkgs {
-          inherit system overlays;
+          inherit system;
+          overlays = [
+            (import rust-overlay)
+          ];
         };
-        naersk' = pkgs.callPackage naersk {};
+        toolchain = pkgs.rust-bin.stable.latest.default;
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = toolchain;
+          cargo = toolchain;
+        };
       in {
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
+            alejandra
             nil
-            pkg-config
-            openssl
-            glib
-            libiconv
+            toolchain
+            rust-analyzer
+          ];
+        };
+        packages.default = rustPlatform.buildRustPackage {
+          src = ./.;
+          copyLibs = true;
+          name = "brack";
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+          buildInputs = with pkgs; [
             darwin.Security
             darwin.apple_sdk.frameworks.SystemConfiguration
-            (fenix.packages.${system}.complete.withComponents [
-              "cargo"
-              "clippy"
-              "rust-src"
-              "rustc"
-              "rustfmt"
-            ])
-            rust-analyzer-nightly
           ];
-          RUST_SRC_PATH = "${fenix.packages.${system}.complete.rust-src}/lib/rustlib/src/rust/library";
-          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
-        };
-        packages.default = naersk'.buildPackage {
-          src = ./.;
         };
         apps.${system}.default = {
           type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -43,9 +43,11 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
           };
+          nativeBuildInputs = with pkgs; [
+            pkgs-config
+          ];
           buildInputs = with pkgs;
             [
-              pkg-config
               openssl
               openssl.dev
             ]

--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,11 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
           };
-          buildInputs = with pkgs.darwin;
-            pkgs.lib.optional pkgs.stdenv.isDarwin [
-              Security
-              apple_sdk.frameworks.SystemConfiguration
+          buildInputs = with pkgs;
+            [pkgconfig]
+            ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
+              darwin.Security
+              darwin.apple_sdk.frameworks.SystemConfiguration
             ];
         };
         apps.${system}.default = {

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
             lockFile = ./Cargo.lock;
           };
           buildInputs = with pkgs;
-            [pkgconfig]
+            [pkg-config]
             ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
               darwin.Security
               darwin.apple_sdk.frameworks.SystemConfiguration

--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,11 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
           };
-          buildInputs = with pkgs; [
-            darwin.Security
-            darwin.apple_sdk.frameworks.SystemConfiguration
-          ];
+          buildInputs = with pkgs.darwin;
+            pkgs.lib.optional pkgs.stdenv.isDarwin [
+              Security
+              apple_sdk.frameworks.SystemConfiguration
+            ];
         };
         apps.${system}.default = {
           type = "app";

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,11 @@
             lockFile = ./Cargo.lock;
           };
           buildInputs = with pkgs;
-            [pkg-config]
+            [
+              pkg-config
+              openssl
+              openssl.dev
+            ]
             ++ pkgs.lib.optional pkgs.stdenv.isDarwin [
               darwin.Security
               darwin.apple_sdk.frameworks.SystemConfiguration


### PR DESCRIPTION
close #26 #29 #30 

We can't build this project with Nix because (maybe) modsurfer, a dependency package to parse wasm binary and get function names, doesn't publish to crate.io.
I removed it and checked to build successfully using the CI workflow.

- It changes the plugin specification so that the brack plugin must provide a `get_metadata` function that returns `Vec<Metadata>`.